### PR TITLE
Small UI improvements

### DIFF
--- a/iOSDevUK/Presentation/HomeView/HomeView.swift
+++ b/iOSDevUK/Presentation/HomeView/HomeView.swift
@@ -52,7 +52,6 @@ struct HomeView: View {
             .padding(.leading)
 
         }
-        .padding(.bottom)
     }
 
     @ViewBuilder
@@ -81,7 +80,6 @@ struct HomeView: View {
             .scrollIndicators(.hidden)
             .padding(.leading)
         }
-        .padding(.bottom)
     }
     
     @ViewBuilder
@@ -114,15 +112,16 @@ struct HomeView: View {
     @ViewBuilder
     private func main() -> some View {
         ScrollView {
-            if viewModel.eventInformation != nil {
-                headerView()
+            VStack(spacing: 16) {
+                if viewModel.eventInformation != nil {
+                    headerView()
+                }
+                sessionView()
+                speakerView()
+                footerView()
             }
-            sessionView()
-            speakerView()
-            footerView()
         }
         .scrollIndicators(.hidden)
-        .padding(.vertical)
     }
 
     var body: some View {

--- a/iOSDevUK/Presentation/HomeView/HomeView.swift
+++ b/iOSDevUK/Presentation/HomeView/HomeView.swift
@@ -56,7 +56,6 @@ struct HomeView: View {
 
     @ViewBuilder
     private func speakerView() -> some View {
-        
         VStack(alignment: .leading) {
             HStack {
                 Text("Speakers") .font(.title2).bold()
@@ -65,14 +64,12 @@ struct HomeView: View {
             }
             .padding(.horizontal)
 
-            
             ScrollView(.horizontal) {
                 LazyHStack(spacing: 10) {
                     ForEach(viewModel.speakers) { speaker in
-                       
                         NavigationLink(value: Destination.speaker(speaker)) {
                             SpeakerCardView(speaker: speaker)
-                                .frame(width: 130, height: 200)
+                                .frame(width: 130)
                         }
                     }
                 }
@@ -112,7 +109,7 @@ struct HomeView: View {
     @ViewBuilder
     private func main() -> some View {
         ScrollView {
-            VStack(spacing: 16) {
+            VStack(spacing: 20) {
                 if viewModel.eventInformation != nil {
                     headerView()
                 }

--- a/iOSDevUK/Presentation/SecondaryViews/Sessions/SessionDetailView/SessionDetailView.swift
+++ b/iOSDevUK/Presentation/SecondaryViews/Sessions/SessionDetailView/SessionDetailView.swift
@@ -42,7 +42,8 @@ struct SessionDetailView: View {
                 .font(.title2)
                 .foregroundColor(.gray)
                 .bold()
-                .padding(.vertical)
+                .padding(.top)
+                .padding(.bottom, 5)
             
             Text(viewModel.session?.content ?? "")
                 .multilineTextAlignment(.leading)
@@ -59,7 +60,8 @@ struct SessionDetailView: View {
                 .font(.title3)
                 .foregroundColor(.gray)
                 .bold()
-                .padding(.bottom)
+                .padding(.top)
+                .padding(.bottom, 5)
             
             ForEach(viewModel.speakers ?? []) { speaker in
                 
@@ -81,7 +83,8 @@ struct SessionDetailView: View {
                 .font(.title3)
                 .foregroundColor(.gray)
                 .bold()
-                .padding(.bottom)
+                .padding(.top)
+                .padding(.bottom, 5)
 
                 NavigationLink(value: Destination.locations([location])) {
                     Text(location.name)

--- a/iOSDevUK/Presentation/SecondaryViews/SpeakerView/SpeakerDetailView/SpeakerDetailView.swift
+++ b/iOSDevUK/Presentation/SecondaryViews/SpeakerView/SpeakerDetailView/SpeakerDetailView.swift
@@ -22,7 +22,6 @@ struct SpeakerDetailView: View {
     
     @ViewBuilder
     private func headerView() -> some View {
-        
         HStack {
             RemoteImageView(url: viewModel.speaker.imageUrl)
                 .cornerRadius(15)
@@ -53,7 +52,8 @@ struct SpeakerDetailView: View {
             .font(.title2)
             .bold()
             .foregroundColor(.gray)
-            .padding(.vertical)
+            .padding(.top)
+            .padding(.bottom, 5)
         
         Text(viewModel.speaker.biography)
             .multilineTextAlignment(.leading)
@@ -66,6 +66,7 @@ struct SpeakerDetailView: View {
             Text("\(session.title)")
                 .font(.subheadline)
                 .lineLimit(2)
+                .multilineTextAlignment(.leading)
                 
             Text("\(session.duration)")
                 .font(.caption)
@@ -77,16 +78,17 @@ struct SpeakerDetailView: View {
     
     @ViewBuilder
     private func sessionsView() -> some View {
-
         if !viewModel.sessions.isEmpty {
+            Divider()
+            
             Text("Session(s)")
                 .font(.title3)
                 .foregroundColor(.gray)
                 .bold()
-                .padding(.vertical, 10)
+                .padding(.top)
+                .padding(.bottom, 5)
             
             ForEach(viewModel.sessions) { session in
-                
                 NavigationLink(value: Destination.session(session)) {
                     sessionsRaw(session: session)
                 }
@@ -96,18 +98,16 @@ struct SpeakerDetailView: View {
     
     @ViewBuilder
     private func main() -> some View {
-        
         ScrollView {
             VStack(alignment: .leading) {
                 headerView()
                 Divider()
                 descriptionView()
-                Divider()
                 sessionsView()
             }
+            .padding()
         }
         .scrollIndicators(.hidden)
-        .padding()
         .alert(isPresented: $viewModel.showError, content: {
             Alert(title: Text("Error!"), message: Text(viewModel.fetchError?.localizedDescription ?? ""), dismissButton: .default(Text("OK")))
         })


### PR DESCRIPTION
This PR makes some small UI improvements:

- Remove paddings from ScrollViews as these result in white borders on top and bottom:
  | Before | After |
  | ------ | ------|
  | ![Previous](https://user-images.githubusercontent.com/4720036/223087558-3361b6dc-c3e5-46be-946b-dcb69b485c66.png) | ![New](https://user-images.githubusercontent.com/4720036/223091324-cb863e99-a150-41f9-83c8-fe46727e0feb.png) |
- Make multiline session titles in speaker screen align properly
  | Before | After |
  | ------ | ------|
  | ![Before](https://user-images.githubusercontent.com/4720036/223088828-6ff32a27-2d47-4b89-8a09-dc73c9c9f363.png) | ![After](https://user-images.githubusercontent.com/4720036/223088840-8614569a-5902-4abc-92ec-8e908fa2daa8.png) |
- Update paddings on headlines to make them more connected to the content
- Remove divider below biography on speaker view, when speaker has no sessions
- Small spacing adjustments on home screen