### PR TITLE
Fix sponsor images stretching

### DIFF
--- a/iOSDevUK/ViewComponents/SponsorRow.swift
+++ b/iOSDevUK/ViewComponents/SponsorRow.swift
@@ -19,9 +19,9 @@ struct SponsorRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             RemoteImageView(url: colorScheme == .dark ? sponsor.imageUrlDark : sponsor.imageUrlLight)
+                .aspectRatio(contentMode: .fit)
                 .frame(height: 150)
                 .frame(maxWidth: .infinity)
-                .aspectRatio(contentMode: .fit)
             
             ZStack(alignment: .center) {
                 RoundedRectangle(cornerRadius: 10)


### PR DESCRIPTION
Before vs After
<img width="945" alt="Screenshot 2023-08-05 at 15 18 34" src="https://github.com/DavidFaraday/iOSDevUK/assets/5704018/e9093d46-7556-4cfb-8289-c46e53cc46bf">
