### PR TITLE
Adjustment to use of images for navigation view items

### DIFF
--- a/iOSDevUK/Utils/Constants.swift
+++ b/iOSDevUK/Utils/Constants.swift
@@ -16,7 +16,7 @@ struct AppStrings {
     static let slackChannel = "iOSDevUK Slack Channel"
     static let iOSDevTwitter = "@iOSDevUK on Twitter"
     static let aberCompTwitter = "@AberCompSci on Twitter"
-    static let iOSDevUK = "iOSDev UK"
+    static let iOSDevUK = "iOSDevUK"
     static let mySessions = "My Sessions"
     static let emptySessionMessage = "You currently have no sessions added. \n Please bookmark sessions to see them here."
     static let takeMeThere = "Take me there"

--- a/iOSDevUK/ViewComponents/NavigationRowView.swift
+++ b/iOSDevUK/ViewComponents/NavigationRowView.swift
@@ -14,7 +14,11 @@ struct NavigationRowView: View {
     var body: some View {
         HStack {
             Image(systemName: systemImageName)
+                .font(.title3)
+                .frame(width: 40)
+                .dynamicTypeSize(.medium ... .accessibility1)
             Text(title)
+                .padding(.leading, 10)
         }
     }
 }


### PR DESCRIPTION
Two small changes. The first is changing name used on front screen from "iOSDev UK" to one word. The other is an adjustment regarding the SF Symbols use. When testing with dynamic type, it is difficult to handle large sizes for the widest symbols, so I have put a limit on the range of valid sizes. The width is set for the frame around the image so that the text is aligned correctly for all items. There is some padding on the text to handle the largest dynamic text sizes.