### PR TITLE
CloudKit integration with Updated with project file with background mode

### DIFF
--- a/iOSDevUK.xcodeproj/project.pbxproj
+++ b/iOSDevUK.xcodeproj/project.pbxproj
@@ -984,6 +984,7 @@
 				DEVELOPMENT_TEAM = 7P6AJEE272;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSDevUK/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "iOSDevUK uses your location to show on the map.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -1016,6 +1017,7 @@
 				DEVELOPMENT_TEAM = 7P6AJEE272;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSDevUK/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "iOSDevUK uses your location to show on the map.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/iOSDevUK/Domains/SessionDetailViewModel.swift
+++ b/iOSDevUK/Domains/SessionDetailViewModel.swift
@@ -99,20 +99,30 @@ final class SessionDetailViewModel: ObservableObject {
         self.fetchError = nil
     }
     
+    
+    /// Add the current session to the CoreData store for the `My Sessions` list.
+    /// The code checks that there isn't already an entry with the same identifier in the data store. If there is no match,
+    /// a new record is added to the data store, which is then propagated to other connected devices using
+    /// Core Data and CloudKit synchronisation.
+    ///
+    /// - Parameter context: The Core Data context that will manage the data.
     func addToMySession(context: NSManagedObjectContext) {
         guard let session = session else { return }
 
-        let cdSession = SavedSession(context: context)
-        cdSession.title = session.title
-        cdSession.id = session.id
-        cdSession.startDate = session.startDate
-        cdSession.endDate = session.endDate
-        cdSession.content = session.content
-        cdSession.startDateName = session.startingDay
-        cdSession.locationName = location?.name
-        cdSession.locationId = location?.id
-        
-        DataController.save(context: context)
+        let exists = DataController.entityExists(forId: sessionId, inContext: context)
+        if !exists.description.isEmpty {
+            let cdSession = SavedSession(context: context)
+            cdSession.title = session.title
+            cdSession.id = session.id
+            cdSession.startDate = session.startDate
+            cdSession.endDate = session.endDate
+            cdSession.content = session.content
+            cdSession.startDateName = session.startingDay
+            cdSession.locationName = location?.name
+            cdSession.locationId = location?.id
+            
+            DataController.save(context: context)
+        }
     }
     
     func removeFromMySessions(savedSession: SavedSession, context: NSManagedObjectContext) {

--- a/iOSDevUK/Model/CoreData/DataController.swift
+++ b/iOSDevUK/Model/CoreData/DataController.swift
@@ -9,9 +9,13 @@ import Foundation
 import CoreData
 
 class DataController: ObservableObject {
-    let container = NSPersistentContainer(name: "iOSDevUK")
+    
+    /// Container that will manage synchronisation to local persistance store and to connected devices via Cloud Kit.
+    let container = NSPersistentCloudKitContainer(name: "iOSDevUK")
     
     init() {
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        
         container.loadPersistentStores { description, error in
             if let error = error {
                 print("Core data failed to load \(error.localizedDescription)")
@@ -22,6 +26,31 @@ class DataController: ObservableObject {
         }
     }
     
+    
+    /// Checks is there is an existing entry in the managed object context for a session with the given id.
+    /// - Parameters:
+    ///   - id: The unique identifer for the session.
+    ///   - context: The Core Data context that manages the store.
+    /// - Returns: True if there is no record in the object context for the given id. Otherwise, false is returned. If there is an error, false is returned.
+    static func entityExists(forId id: String, inContext context: NSManagedObjectContext) -> Bool {
+        
+        let existingRequest = NSFetchRequest<SavedSession>(entityName: "SavedSession")
+        existingRequest.predicate = NSPredicate(format: "id == %@", id)
+        
+        do {
+            let existingSessions = try context.fetch(existingRequest)
+            return !existingSessions.isEmpty
+        }
+        catch(let error) {
+            print("Unable to access request for existing records: \(error.localizedDescription)")
+        }
+        
+        return false
+    }
+    
+    
+    /// Save the data in the current managed object context.
+    /// - Parameter context: The managed object context for this persistance store.
     static func save(context: NSManagedObjectContext) {
         
         if context.hasChanges {

--- a/iOSDevUK/Model/CoreData/iOSDevUK.xcdatamodeld/iOSDevUK.xcdatamodel/contents
+++ b/iOSDevUK/Model/CoreData/iOSDevUK.xcdatamodeld/iOSDevUK.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="22A380" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22G74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
     <entity name="SavedSession" representedClassName="SavedSession" syncable="YES" codeGenerationType="class">
         <attribute name="content" optional="YES" attributeType="String"/>
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -9,10 +9,5 @@
         <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="startDateName" optional="YES" attributeType="String"/>
         <attribute name="title" optional="YES" attributeType="String"/>
-        <uniquenessConstraints>
-            <uniquenessConstraint>
-                <constraint value="id"/>
-            </uniquenessConstraint>
-        </uniquenessConstraints>
     </entity>
 </model>

--- a/iOSDevUK/iOSDevUK.entitlements
+++ b/iOSDevUK/iOSDevUK.entitlements
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.uk.ac.aber.iOSDevUK-test1</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.developer.weatherkit</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Added new capabilities to the project to allow Core Data synchronisation between devices, using CloudKit. The additional capabilities are iCloud, Push Notifications (added when Cloud capability added) and Background Mode. A container is created in iCloud to manage the data as it is moved between devices.  The Background Mode is needed to handle remote notifications in the background.

The Core Data model is changed to remove the unique constraint on the id. This is needed so that the data store is compatible with the Cloud Kit code. 

The `DataController` class has also been modified to allow for a CloudKit persistence container that will manage most of the work.

The `SessionDetailViewModel` is updated to check if an entity with the session id is in the Core Data store before it attempts to write a new instance. 

Some DocC comments have been added.