### PR TITLE
Small UI updates to colour and adding speaker names

### DIFF
--- a/iOSDevUK/Domains/SessionRowViewModel.swift
+++ b/iOSDevUK/Domains/SessionRowViewModel.swift
@@ -12,6 +12,26 @@ final class SessionRowViewModel: ObservableObject {
     @Injected(\.firebaseRepository) private var firebaseRepository
     @Published private(set) var fetchError: Error?
     @Published private(set) var location: Location?
+    @Published private(set) var speakers: [Speaker]?
+    
+    @MainActor
+    @Sendable func fetchSpeakers(with speakerIds: [String]) async {
+        guard speakers == nil else { return }
+
+        var tempSpeakers: [Speaker] = []
+                
+        for id in speakerIds {
+            do {
+                let speaker: Speaker? = try await firebaseRepository.getDocument(from: .Speaker, with: id)
+                guard let speaker = speaker else { return }
+                tempSpeakers.append(speaker)
+            } catch (let error) {
+                fetchError = error
+            }
+        }
+        
+        self.speakers = tempSpeakers
+    }
        
     @MainActor
     func fetchLocation(with id: String?) async {
@@ -23,5 +43,17 @@ final class SessionRowViewModel: ObservableObject {
                 fetchError = error
             }
         }
+    }
+    
+    func speakerNames() -> String {
+
+        guard let speakers = speakers else { return "" }
+        
+        let sortedNames = speakers.sorted()
+        
+        var joinedNames = ""
+        joinedNames.append(sortedNames.map{ "\($0.name)" }.joined(separator: ", "))
+       
+        return joinedNames
     }
 }

--- a/iOSDevUK/Presentation/SecondaryViews/Sessions/SessionRowView/SessionRowForLocalSession.swift
+++ b/iOSDevUK/Presentation/SecondaryViews/Sessions/SessionRowView/SessionRowForLocalSession.swift
@@ -15,7 +15,7 @@ struct SessionRowForLocalSession: View {
         HStack {
             VStack {
                 Text("\(session.startDate?.time ?? AppStrings.loading)")
-                    .foregroundColor(.red)
+                    .foregroundColor(.accentColor)
                 Text("\(session.endDate?.time ?? AppStrings.loading)")
             }
             .font(.caption)

--- a/iOSDevUK/Presentation/SecondaryViews/Sessions/SessionRowView/SessionRowView.swift
+++ b/iOSDevUK/Presentation/SecondaryViews/Sessions/SessionRowView/SessionRowView.swift
@@ -12,7 +12,7 @@ struct SessionRowView: View {
     let session: Session
     
     var body: some View {
-        HStack(alignment: .top) {
+        HStack {
             VStack {
                 Text(session.startDate.time)
                     .foregroundColor(.accentColor)
@@ -24,6 +24,8 @@ struct SessionRowView: View {
             VStack(alignment: .leading, spacing: 10) {
                 Text(session.title)
                     .font(.title3)
+                Text(viewModel.speakerNames())
+                    .padding(.trailing)
                 Text(viewModel.location?.name ?? "")
                     .font(.caption)
                     .foregroundColor(.gray)
@@ -32,6 +34,7 @@ struct SessionRowView: View {
             .lineLimit(2)
         }
         .task {
+            await viewModel.fetchSpeakers(with: session.speakerIds)
             await viewModel.fetchLocation(with: session.locationId)
         }
     }

--- a/iOSDevUK/ViewComponents/SponsorRow.swift
+++ b/iOSDevUK/ViewComponents/SponsorRow.swift
@@ -39,7 +39,7 @@ struct SponsorRow: View {
             
             Text(sponsor.urlText)
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundColor(.accentColor)
         }
     }
 }


### PR DESCRIPTION
Adjustment to the following:

* `SessionRowViewModel` updated with function to lookup speaker details. Those speaker details are accessed from `SessionRowView`. 
* The vertical alignment is reset for the times - going back to the centre alignment that you had originally. That now matches the vertical alignment in the `MyScheduleView` list.
* Accent colour used for consistency on start time in the `MyScheduleView`.
* Accent colour used for name on weblink in the Sponsor row. It was previously gray. I think it would be better to look like a link, even though the entire row can be tapped. 