### PR TITLE
Adding description text (subtitle) to footer for Attendee items.

### DIFF
--- a/iOSDevUK/MOCK/DummyData.swift
+++ b/iOSDevUK/MOCK/DummyData.swift
@@ -84,8 +84,8 @@ struct DummyData {
     static let contentForSession = "when an unknown printer."
 
     static let informationItems = [
-        InformationItem(id: UUID().uuidString, name: "Tickets", link: "http://users.aber.ac.uk/nst/iosdevuk/jump.php?to=tickets", imageName: "questionmark"),
-        InformationItem(id: UUID().uuidString, name: "Joining Instructions", link: "http://users.aber.ac.uk/nst/iosdevuk/jump.php?to=joining", imageName: "questionmark")
+        InformationItem(id: UUID().uuidString, name: "Tickets", subtitle: "Eventbrite link for tickets", link: "http://users.aber.ac.uk/nst/iosdevuk/jump.php?to=tickets", imageName: "questionmark"),
+        InformationItem(id: UUID().uuidString, name: "Joining Instructions", subtitle: "PDF with information in Aber", link: "http://users.aber.ac.uk/nst/iosdevuk/jump.php?to=joining", imageName: "questionmark")
     ]
 
     static let location = Location(id: "TestLocation123" ,name: "Great Hall", note: "Some notes about the location", imageLink: "https://picsum.photos/200", latitude: 52.416120, longitude: -4.083800, webLink: DummyData.link, locationType: .pubs)

--- a/iOSDevUK/Model/InformationItem.swift
+++ b/iOSDevUK/Model/InformationItem.swift
@@ -11,6 +11,7 @@ struct InformationItem: Codable, Identifiable, Comparable {
     
     let id: String
     let name: String
+    let subtitle: String
     let link: String
     let imageName: String?
     

--- a/iOSDevUK/Presentation/AttendeeView/AttendeeView.swift
+++ b/iOSDevUK/Presentation/AttendeeView/AttendeeView.swift
@@ -16,8 +16,12 @@ struct AttendeeView: View {
         Form {
             ForEach(viewModel.infoItems) { item in
                 if let url = item.url {
-                    Link(destination: url) {
-                        NavigationRowView(systemImageName: item.imageName ?? ImageNames.questionmark, title: item.name)
+                    Section {
+                        Link(destination: url) {
+                            NavigationRowView(systemImageName: item.imageName ?? ImageNames.questionmark, title: item.name)
+                        }
+                    } footer: {
+                        Text(item.subtitle)
                     }
                 } else {
                     Text(item.name)


### PR DESCRIPTION
In the email discussion, I had suggested that we add some explanation text to the items on the `AttendeeView`.  In UIKit, we might have done this with a subtitle on the row. Apple doesn't seem to use that approach on modern apps. Instead, it uses footers on Sections in forms. This request splits the items into `Section` items in the `Form` for `AttendeeView` and adds a footer. 

This change would require an extra field in each `InformationItem` on Firebase. That is mirrored in the Model class. 