### PR TITLE
Fix for re-processing groups in MyScheduleView

### DIFF
--- a/iOSDevUK/Domains/MyScheduleViewModel.swift
+++ b/iOSDevUK/Domains/MyScheduleViewModel.swift
@@ -26,13 +26,7 @@ final class MyScheduleViewModel: ObservableObject {
     private func observerData() {
         $sessions
             .sink(receiveValue: { receivedSessions in
-                
-                let filteredSessions = receivedSessions.filter { self.favoriteSessionIds.contains($0.id) }
-
-                self.groupedSessions = .init(
-                    grouping: filteredSessions,
-                    by: { $0.startingDay }
-                )
+                self.updateGroupedSessions(sessions: receivedSessions)
             })
             .store(in: &cancellables)
     }
@@ -62,6 +56,16 @@ final class MyScheduleViewModel: ObservableObject {
     
     func setFavSessions(favSessionIds: [String]) {
         self.favoriteSessionIds = favSessionIds
+        updateGroupedSessions(sessions: self.sessions)
+    }
+    
+    private func updateGroupedSessions(sessions: [Session]) {
+        let filteredSessions = sessions.filter { self.favoriteSessionIds.contains($0.id) }
+
+        self.groupedSessions = .init(
+            grouping: filteredSessions,
+            by: { $0.startingDay }
+        )
     }
     
     

--- a/iOSDevUK/Presentation/MyScheduleView/MyScheduleView.swift
+++ b/iOSDevUK/Presentation/MyScheduleView/MyScheduleView.swift
@@ -37,6 +37,7 @@ struct MyScheduleView: View {
                                 SessionRowView(session: session,
                                                location: baseViewModel.getLocation(with: session.locationId),
                                                speakers: baseViewModel.getSpeakers(with: session.speakerIds) )
+                                .id(session)
                             }
                         }
                         .onDelete { indexSet in


### PR DESCRIPTION
Most of the data is updated, but any changes to the array of names are not detected. Adding `.id(session)` in MyScheduleView will address this.

The MyScheduleView groups are only rebuilt if there is a change in the list of sessions. If the update to the MyScheduleView is generated by new sessions, the groups are rebuilt. If the update is generated by `onAppearance`, then the groups are not regenerated. The proposed change is to rebuild groups in both situations.